### PR TITLE
docs: reconcile accrual events and vesting docs by huazhuang80-star

### DIFF
--- a/docs/accrual-spec.md
+++ b/docs/accrual-spec.md
@@ -2,10 +2,21 @@
 
 **Document:** `docs/accrual-spec.md`  
 **Contract:** `StreamPay-Contracts` (Soroban / Rust)  
-**Version:** 0.1.0 (`VERSION = 1_000`)  
+**Version:** 0.2.0 (`VERSION = 2_000`)
 **Status:** Normative — matches `src/lib.rs` line-by-line
 
 ---
+
+## Current implementation note
+
+This document now tracks the current `src/lib.rs` surface: `VERSION = 2_000`,
+pause/resume entrypoints, SEP-41 token custody on creation and withdrawal, and
+the `claimable_balance` settlement model. `settle_stream` moves accrued value
+from `balance` into `claimable_balance`; `withdraw_stream` performs the
+recipient-authorized on-ledger transfer and resets claimable funds to zero.
+
+Linear vesting streams are covered separately in
+[`vesting-spec.md`](./vesting-spec.md).
 
 ## 1. Overview
 

--- a/docs/error-codes.md
+++ b/docs/error-codes.md
@@ -12,10 +12,17 @@ and what each one means for an integrator.
 | `memo exceeds 32 chars` | `create_stream` | The optional memo string is longer than 32 bytes. |
 | `stream already active` | `start_stream` | Trying to start a stream whose `is_active` flag is already true. |
 | `stream not active` | `stop_stream` | Trying to stop a stream that is already stopped. |
-| `unauthorized stopper` | `stop_stream` | The caller is neither the payer nor a recipient with `recipient_can_stop = true`. |
+| `cannot cancel inactive stream` | `cancel_stream` | The payer attempted to cancel a stream that is not active. |
+| `cannot pause inactive stream` | `pause_stream` | The payer attempted to pause a stream that is not active. |
+| `stream already paused` | `pause_stream` | The stream is already paused. |
+| `cannot resume inactive stream` | `resume_stream` | The payer attempted to resume a stream that is not active. |
+| `stream is not paused` | `resume_stream` | The stream is active and not currently paused. |
 | `batch too large` | `batch_settle` | Caller passed more than `MAX_BATCH_SETTLE_SIZE` (25) ids. |
-| `stream still has balance` | `archive_stream` | Balance is not fully settled and withdrawn. |
-| `stream still active` | `archive_stream` | Stream is still active; stop it first. |
+| `cannot archive active stream` | `archive_stream` | Stream is still active; stop it first. |
+| `cannot archive stream with unsettled balance` | `archive_stream` | Balance is not fully settled. |
+| `cannot archive stream with unclaimed balance` | `archive_stream` | Recipient still has claimable balance to withdraw. |
+| `rate must be positive` | `create_vesting_stream` | Vesting duration or rate configuration would create a non-positive stream rate. |
+| `rate increase exceeds 10% limit` | rate update flow | Requested rate increase exceeds the contract safety bound. |
 
 ## Why panic strings instead of error enums?
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -18,6 +18,8 @@ symbol is the constant `"stream"`; the second is the action name.
 | `(stream, settled)` | `settle_stream` | `(stream_id, amount, new_balance, new_claimable)` |
 | `(stream, withdrawn)` | `withdraw_stream` | `(stream_id, recipient, amount)` |
 | `(stream, archived)` | `archive_stream` | `(stream_id, payer)` |
+| `(stream, paused)` | `pause_stream` | `(stream_id, pause_time)` |
+| `(stream, resumed)` | `resume_stream` | `(stream_id, resume_time)` |
 
 ## Field notes
 
@@ -30,6 +32,8 @@ symbol is the constant `"stream"`; the second is the action name.
 - Maintain `(stream_id -> running_total_claimed)` by summing `withdrawn`
   amounts; never sum `settled` amounts, since settlements may be batched
   and overlap with the same withdrawal window.
+- Track `claimable_balance` from settled/withdrawn events if the indexer needs
+  pending recipient withdrawals.
 - Use `(stream, archived)` as the signal to delete the stream from your
   active index. Once observed, no further events for that id can occur.
 - Topic ordering inside a single transaction is deterministic and matches

--- a/docs/vesting-spec.md
+++ b/docs/vesting-spec.md
@@ -1,0 +1,44 @@
+# Vesting Stream Specification
+
+`create_vesting_stream` creates a stream whose value unlocks linearly across a
+fixed duration. It is intended for grant, payroll, and vesting-style payouts
+where the recipient should not be able to withdraw the full balance at creation.
+
+## Model
+
+- The payer funds the stream up front.
+- The contract records a vesting anchor and duration.
+- As ledger time advances, the unlocked amount grows linearly.
+- `settle_stream` moves unlocked value from `balance` into
+  `claimable_balance`.
+- `withdraw_stream` transfers the claimable amount to the recipient.
+
+## Rounding
+
+Linear vesting can leave a small remainder when the total amount does not divide
+evenly by the duration. The contract tests verify that the final settlement
+releases the rounding remainder when the duration has fully elapsed.
+
+## Pause and resume
+
+Pause/resume preserves already-vested value by settling before the stream is
+paused. Resuming restarts the active accrual window while keeping the original
+vesting schedule anchor intact.
+
+## Indexer guidance
+
+- Treat `settled` events as movement into `claimable_balance`, not as recipient
+  payment.
+- Treat `withdrawn` events as actual on-ledger recipient payment.
+- Use the stream version and schema docs when decoding stored vesting state.
+- Do not infer vesting completion from wall-clock time alone; use ledger
+  timestamps and observed settlement/withdrawal events.
+
+## Tests
+
+The vesting behavior is covered in `src/lib.rs` by tests including:
+
+- `test_vesting_unlocks_linearly_across_multiple_settlements`
+- `test_vesting_releases_rounding_remainder_at_end`
+- `test_vesting_schedule_anchor_persists_across_restart`
+- `test_vesting_unlocks_full_balance_after_duration`


### PR DESCRIPTION
Closes #143.

## Summary
- updates accrual docs with the current `VERSION = 2_000` implementation note
- reconciles panic/error docs with pause/resume/archive behavior
- adds pause/resume event documentation and claimable-balance indexing guidance
- adds a vesting stream specification tied to the current tests

## Validation
- `git diff --check` passed

## Notes
- Documentation-only change; no runtime tests were needed.